### PR TITLE
Remove Content-Security-Policy header from proxied response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *~
 .gradle/
 build/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM --platform=linux/amd64 node:16-slim
 
 WORKDIR /app
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.tivo:tivo-docker-plugin:0.21'
+    classpath 'com.tivo:tivo-docker-plugin:0.28.83'
   }
 }
 
@@ -22,4 +22,6 @@ apply plugin: 'tivo-docker'
 
 tivoDocker {
   imageName = 'eks-auth-proxy'
+  ownerEmail = 'inception-scrum@xperi.com'
+  description = 'The IAM to EKS authentication bridging proxy'
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -32,6 +32,11 @@ proxy.on('proxyReq', (proxyReq, req) => {
 // Log errors
 proxy.on('error', log.error.bind(log));
 
+// Remove the CSP header, which causes problems for the dashboard over https
+proxy.on('proxyRes', function (proxyRes, req, res) {
+    res.removeHeader('Content-Security-Policy')
+});
+
 const proxyMiddleware = (ctx) => {
     ctx.respond = false; // Required to prevent koa from sending out headers
     proxy.web(ctx.req, ctx.res);


### PR DESCRIPTION
For some reason, the http-proxy library is adding a very restrictive CSP, and that policy does not work with the kubernetes-dashboard inlining of some javascript on a style sheet load. Also, update tivo-docker-plugin version.