### PR TITLE
Revert fix-build merge from tivobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN yarn global add pm2 -g
 
 COPY package.json yarn.lock /app/
 
-RUN yarn install --ignore-engines
+RUN yarn install
 
 COPY . /app
 
-CMD ["./start"]
+CMD ./start

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('tivoPipeline') _
 
-emailBreaks('inception-scrum@tivo.com') {
+emailBreaks {
     node('docker') {
         stage('Code Checkout') {
             checkout scm

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     // uncomment to use local repo when testing tivo-docker plugin
     // maven { url "file://${projectDir}/../repo" }
     maven {
-      url 'https://repo-vip.tivo.com:8443/artifactory/plugins-release'
+      url 'http://repo-vip.tivo.com:8081/artifactory/plugins-release'
     }
   }
 


### PR DESCRIPTION
## What
Revert merge commit `874f961` (PR #6 / `fix-build`) from `tivobuild`.
## Why
Need to remove the change introduced by commit `394f4e8` (`Fix build error`) from the `tivobuild` line.
`tivobuild` is branch-protected (no force-push), so this is done as a revert PR.
## Changes
- Revert commit: `239a28f`
- Reverts merge: `874f961`
- Original commit in reverted merge: `394f4e8`
## Notes
This preserves branch protection and audit trail while effectively wiping out the fix-build change from `tivobuild`.
